### PR TITLE
Contract feat

### DIFF
--- a/decentralized-identity-management-system/contracts/decentralized-identity-management.clar
+++ b/decentralized-identity-management-system/contracts/decentralized-identity-management.clar
@@ -249,3 +249,56 @@
     )
   )
 )
+
+(define-map IdentityReputation
+  principal
+  {
+    trust-score: uint,
+    total-verifications: uint,
+    successful-verifications: uint
+  }
+)
+
+;; Update Reputation After Verification
+(define-private (update-reputation
+  (identity principal)
+  (is-successful bool)
+)
+  (match (map-get? IdentityReputation identity)
+    current-reputation
+      (let 
+        (
+          (new-total (+ (get total-verifications current-reputation) u1))
+          (new-successful 
+            (if is-successful 
+              (+ (get successful-verifications current-reputation) u1)
+              (get successful-verifications current-reputation)
+            )
+          )
+          (new-trust-score 
+            (/ 
+              (* (get successful-verifications current-reputation) u100) 
+              new-total
+            )
+          )
+        )
+        (map-set IdentityReputation 
+          identity 
+          {
+            trust-score: new-trust-score,
+            total-verifications: new-total,
+            successful-verifications: new-successful
+          }
+        )
+      )
+    ;; Initialize reputation if not exists
+    (map-set IdentityReputation 
+      identity 
+      {
+        trust-score: (if is-successful u100 u0),
+        total-verifications: u1,
+        successful-verifications: (if is-successful u1 u0)
+      }
+    )
+  )
+)

--- a/decentralized-identity-management-system/contracts/decentralized-identity-management.clar
+++ b/decentralized-identity-management-system/contracts/decentralized-identity-management.clar
@@ -204,3 +204,48 @@
     )
   )
 )
+
+(define-public (revoke-service-access
+  (service-did principal)
+)
+  (let 
+    (
+      (access-entry 
+        (map-get? ServiceAccess 
+          {
+            identity: tx-sender,
+            service-did: service-did
+          }
+        )
+      )
+    )
+    (match access-entry
+      entry
+        (begin
+          ;; Remove service access
+          (map-delete ServiceAccess 
+            {
+              identity: tx-sender,
+              service-did: service-did
+            }
+          )
+          
+          ;; Update verification request status
+          (map-set VerificationRequests
+            {
+              requester: service-did,
+              identity: tx-sender
+            }
+            {
+              requested-attributes: (get allowed-attributes entry),
+              status: "REVOKED",
+              created-at: u0
+            }
+          )
+          
+          (ok true)
+        )
+      (err ERR-SERVICE-ACCESS-DENIED)
+    )
+  )
+)

--- a/decentralized-identity-management-system/contracts/decentralized-identity-management.clar
+++ b/decentralized-identity-management-system/contracts/decentralized-identity-management.clar
@@ -302,3 +302,48 @@
     )
   )
 )
+
+(define-map RecoveryGuardians
+  principal
+  (list 3 principal)
+)
+
+(define-public (add-recovery-guardians
+  (guardians (list 3 principal))
+)
+  (begin
+    (map-set RecoveryGuardians 
+      tx-sender 
+      guardians
+    )
+    (ok true)
+  )
+)
+
+(define-public (verify-identity-for-contract
+  (contract-address principal)
+  (required-attributes (list 10 (string-ascii 50)))
+)
+  (match (map-get? Identities tx-sender)
+    identity
+      (let 
+        (
+          (has-service-access 
+            (is-some 
+              (map-get? ServiceAccess 
+                {
+                  identity: tx-sender,
+                  service-did: contract-address
+                }
+              )
+            )
+          )
+        )
+        (if has-service-access
+          (ok true)
+          (err ERR-SERVICE-ACCESS-DENIED)
+        )
+      )
+    (err ERR-INVALID-IDENTITY)
+  )
+)


### PR DESCRIPTION
### ✅ `revoke-service-access`

**Purpose**:
Revokes a service's access to a user's identity and updates the verification request status to "REVOKED".

**Logic**:

1. Check if there's an access entry for the calling user (`tx-sender`) and the `service-did`.
2. If access exists:

   * Delete the access entry from `ServiceAccess`.
   * Add/update an entry in `VerificationRequests` with:

     * `requested-attributes`: from the previous access entry.
     * `status`: `"REVOKED"`.
     * `created-at`: `u0` (reset/placeholder timestamp).
3. If access doesn't exist, return an error (`ERR-SERVICE-ACCESS-DENIED`).

---

### 🧠 `IdentityReputation` (Map)

**Purpose**:
Stores reputation data for each identity.

**Fields**:

* `trust-score`: a percentage (0–100) based on verification success.
* `total-verifications`: how many times the identity has been verified.
* `successful-verifications`: how many of those verifications were successful.

---

### 🔄 `update-reputation` (Private)

**Purpose**:
Updates a user’s reputation metrics after a verification event.

**Logic**:

1. If a record already exists:

   * Increment total verifications.
   * Conditionally increment successful verifications.
   * Recalculate `trust-score` as:
     `trust-score = (successful-verifications * 100) / total-verifications`
   * Update the map with new values.
2. If no record exists:

   * Initialize a new reputation record with:

     * `trust-score`: `100` if successful, `0` if not.
     * `total-verifications`: `1`
     * `successful-verifications`: `1` if successful, `0` otherwise.

---

### 🛡️ `RecoveryGuardians` (Map)

**Purpose**:
Stores a list of up to 3 designated guardians per identity (used for recovery).

---

### ➕ `add-recovery-guardians`

**Purpose**:
Allows a user to assign up to 3 guardians for identity recovery purposes.

**Logic**:

* Store the list of guardians in `RecoveryGuardians` under the sender's identity (`tx-sender`).
* Return `true`.

---

### ✅ `verify-identity-for-contract`

**Purpose**:
Checks if the calling user (`tx-sender`) has already granted identity access to a specific contract.

**Logic**:

1. Ensure the user is registered in `Identities`.
2. Check if an access entry exists in `ServiceAccess` for the `contract-address`.
3. Return `ok true` if access exists; otherwise, return `ERR-SERVICE-ACCESS-DENIED`.
4. If the identity doesn't exist, return `ERR-INVALID-IDENTITY`.
